### PR TITLE
fix: prevent timeout leak in FlipWords animation

### DIFF
--- a/src/components/hero-background/flip-words.tsx
+++ b/src/components/hero-background/flip-words.tsx
@@ -22,10 +22,13 @@ export const FlipWords = ({
   }, [currentWord, words]);
 
   useEffect(() => {
-    if (!isAnimating)
-      setTimeout(() => {
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    if (!isAnimating) {
+      timeout = setTimeout(() => {
         startAnimation();
       }, duration);
+    }
+    return () => clearTimeout(timeout);
   }, [isAnimating, duration, startAnimation]);
 
   return (


### PR DESCRIPTION
## Summary
- clear pending timeout when FlipWords re-renders or unmounts to avoid memory leaks

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6896f53b8bc4832d88ef62820fc7c61e